### PR TITLE
Manifest Validation, Error Reporting, Sources Handling, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Each Source Entry within the Manifest specifies the source from where to obtain 
 The usual way to construct a Stream is as follows.
 
     entries = [
-      {{:file, "/tmp/hello.pdf"}, "hello.pdf"},
-      {{:file, "/tmp/world.pdf"}, "world.pdf"},
-      {{:url, "https://example.com/foo.pdf"}, "foo/bar.pdf"}
+      [source: {:file, "/tmp/hello.pdf"}, path: "hello.pdf"],
+      [source: {:file, "/tmp/world.pdf"}, path: "world.pdf"],
+      [source: {:url, "https://example.com/foo.pdf"}, path: "foo/bar.pdf"]
     ]
     
     stream = Packmatic.build_stream(entries)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Packmatic
 
-**Packmatic** generates Zip Streams by aggregating File or URL Sources.
+**Packmatic** generates Zip streams by aggregating File or URL Sources.
 
 By using a Stream, the caller can compose it within the confines of Plug’s request/response model and serve the content of the resultant Zip acrhive in a streaming fashion. This allows fast delivery of a Zip archive consisting of many disparate parts hosted in different places, without having to first spool all of them to disk.
 

--- a/lib/packmatic/encoder.ex
+++ b/lib/packmatic/encoder.ex
@@ -1,7 +1,7 @@
 defmodule Packmatic.Encoder do
   @moduledoc """
-  Holds logic which can be used to put together a ZIP file in an interative fashion, suitable for
-  wrapping within a `Stream`. The format of ZIP files emitted by `Packmatic.Encoder` is documented
+  Holds logic which can be used to put together a Zip file in an interative fashion, suitable for
+  wrapping within a `Stream`. The format of Zip files emitted by `Packmatic.Encoder` is documented
   under the modules implementing the `Packmatic.Field` protocol.
 
   The Encoder is wrapped in `Stream.resource/3` for consumption as an Elixir Stream, under

--- a/lib/packmatic/encoder.ex
+++ b/lib/packmatic/encoder.ex
@@ -38,24 +38,22 @@ defmodule Packmatic.Encoder do
   alias __MODULE__.EncodingState
   alias __MODULE__.JournalingState
 
-  @type options :: [{:on_error, :skip | :halt}]
-  @type state_encoding :: EncodingState.t()
-  @type state_journaling :: JournalingState.t()
-  @type ok_start_encoding :: {:ok, :encoding, state_encoding}
-  @type ok_encoding :: {:ok, iolist(), :encoding, state_encoding}
-  @type ok_journaling :: {:ok, iolist(), :journaling, state_journaling}
+  @type option :: {:on_error, :skip | :halt}
+  @type ok_start_encoding :: {:ok, :encoding, EncodingState.t()}
+  @type ok_encoding :: {:ok, iolist(), :encoding, EncodingState.t()}
+  @type ok_journaling :: {:ok, iolist(), :journaling, JournalingState.t()}
   @type ok_done :: {:ok, iolist(), :done, nil}
   @type ok_halt :: {:ok, :halt, :done, nil}
   @type error :: {:error, term()}
 
-  @spec stream_start(Manifest.valid(), options) :: ok_start_encoding
-  @spec stream_start(Manifest.invalid(), options) :: {:error, %Manifest{valid?: false}}
-  @spec stream_next(:encoding, state_encoding) :: ok_encoding | ok_journaling | error
-  @spec stream_next(:journaling, state_journaling) :: ok_journaling | ok_done
+  @spec stream_start(Manifest.valid(), [option]) :: ok_start_encoding
+  @spec stream_start(Manifest.invalid(), [option]) :: {:error, %Manifest{valid?: false}}
+  @spec stream_next(:encoding, EncodingState.t()) :: ok_encoding | ok_journaling | error
+  @spec stream_next(:journaling, JournalingState.t()) :: ok_journaling | ok_done
   @spec stream_next(:done, nil) :: ok_halt
   @spec stream_after(:done, nil) :: :ok
 
-  defdelegate iolist_size(item), to: :erlang
+  import :erlang, only: [iolist_size: 1]
 
   @doc """
   Starts the Stream.
@@ -64,11 +62,11 @@ defmodule Packmatic.Encoder do
   returned.
   """
   def stream_start(manifest, options) do
-    with %Manifest{valid?: true} <- manifest do
+    with %{valid?: true} <- manifest do
       on_error = Keyword.get(options, :on_error, :halt)
       {:ok, :encoding, %EncodingState{remaining: manifest.entries, on_error: on_error}}
     else
-      _ -> {:error, manifest}
+      manifest -> {:error, manifest}
     end
   end
 
@@ -84,6 +82,7 @@ defmodule Packmatic.Encoder do
 
   When the Stream is in `:done` status, it can not be iterated further.
   """
+  def stream_next(status, state)
   def stream_next(:encoding, %EncodingState{} = state), do: stream_encode(state)
   def stream_next(:journaling, %JournalingState{} = state), do: stream_journal(state)
   def stream_next(:done, nil), do: {:ok, :halt, :done, nil}
@@ -91,13 +90,12 @@ defmodule Packmatic.Encoder do
   @doc """
   Completes the Stream.
   """
-  def stream_after(_, _), do: :ok
+  def stream_after(_status, _state), do: :ok
 
   defp stream_encode(%{current: nil, remaining: [entry | rest]} = state) do
-    case {Source.build(entry.source), state.on_error} do
-      {{:ok, source}, _} -> stream_encode_start(source, entry, %{state | remaining: rest})
-      {{:error, reason}, :halt} -> {:error, reason}
-      {{:error, reason}, :skip} -> stream_encode_skip(entry, reason, %{state | remaining: rest})
+    case Source.build(entry.source) do
+      {:ok, source} -> stream_encode_start(entry, source, %{state | remaining: rest})
+      {:error, reason} -> stream_encode_start_error(entry, reason, %{state | remaining: rest})
     end
   end
 
@@ -110,21 +108,26 @@ defmodule Packmatic.Encoder do
   end
 
   defp stream_encode(%{remaining: []} = state) do
-    state = close_zstream(state)
+    state = zstream_close(state)
     state = %JournalingState{remaining: state.encoded, offset: state.bytes_emitted}
     {:ok, [], :journaling, state}
   end
 
-  defp stream_encode_start(source, entry, %{current: nil} = state) do
-    state = reset_zstream(state)
+  defp stream_encode_start(entry, source, state) do
     data = encode_local_file_header(entry)
     info = %EncodingState.EntryInfo{offset: state.bytes_emitted}
+    state = zstream_reset(state)
     state = %{state | current: {entry, source, info}}
     stream_emit(data, :encoding, state)
   end
 
-  defp stream_encode_skip(entry, reason, %{current: nil, on_error: :skip} = state) do
-    stream_emit([], :encoding, %{state | encoded: [{entry, {:error, reason}} | state.encoded]})
+  defp stream_encode_start_error(entry, reason, %{on_error: :skip} = state) do
+    state = %{state | encoded: [{entry, {:error, reason}} | state.encoded]}
+    stream_emit([], :encoding, state)
+  end
+
+  defp stream_encode_start_error(_entry, reason, %{on_error: :halt}) do
+    {:error, reason}
   end
 
   defp stream_encode_data(data, %{current: {entry, source, info}} = state) do
@@ -153,14 +156,6 @@ defmodule Packmatic.Encoder do
     {:error, reason}
   end
 
-  defp stream_journal(%{current: nil, remaining: [{_entry, {:error, _}} | rest]} = state) do
-    stream_journal(%{state | remaining: rest})
-  end
-
-  defp stream_journal(%{current: nil, remaining: [{entry, {:ok, info}} | rest]} = state) do
-    stream_journal(%{state | current: {entry, info}, remaining: rest})
-  end
-
   defp stream_journal(%{current: {entry, info}} = state) do
     data = encode_central_file_header(entry, info)
     state = %{state | current: nil, entries_emitted: state.entries_emitted + 1}
@@ -172,6 +167,14 @@ defmodule Packmatic.Encoder do
     stream_emit(data, :done, nil)
   end
 
+  defp stream_journal(%{current: nil, remaining: [{entry, {:ok, info}} | rest]} = state) do
+    stream_journal(%{state | current: {entry, info}, remaining: rest})
+  end
+
+  defp stream_journal(%{current: nil, remaining: [{_, {:error, _}} | rest]} = state) do
+    stream_journal(%{state | remaining: rest})
+  end
+
   defp stream_emit(item, status, %{bytes_emitted: _} = state) do
     {:ok, item, status, %{state | bytes_emitted: state.bytes_emitted + iolist_size(item)}}
   end
@@ -180,7 +183,7 @@ defmodule Packmatic.Encoder do
     {:ok, item, status, state}
   end
 
-  defp reset_zstream(%{zstream: nil} = state) do
+  defp zstream_reset(%{zstream: nil} = state) do
     # See Erlang/OTP source for :zip.put_z_file/10
     # See http://erlang.org/doc/man/zlib.html#deflateInit-1
     #
@@ -196,16 +199,16 @@ defmodule Packmatic.Encoder do
     %{state | zstream: zstream}
   end
 
-  defp reset_zstream(%{zstream: zstream} = state) do
+  defp zstream_reset(%{zstream: zstream} = state) do
     :ok = :zlib.deflateReset(zstream)
     state
   end
 
-  defp close_zstream(%{zstream: nil} = state) do
+  defp zstream_close(%{zstream: nil} = state) do
     state
   end
 
-  defp close_zstream(%{zstream: zstream} = state) do
+  defp zstream_close(%{zstream: zstream} = state) do
     :ok = :zlib.close(zstream)
     %{state | zstream: nil}
   end

--- a/lib/packmatic/encoder.ex
+++ b/lib/packmatic/encoder.ex
@@ -78,7 +78,6 @@ defmodule Packmatic.Encoder do
 
   When the Stream is in `:done` status, it can not be iterated further.
   """
-
   def stream_next(:encoding, %EncodingState{} = state), do: stream_encode(state)
   def stream_next(:journaling, %JournalingState{} = state), do: stream_journal(state)
   def stream_next(:done, nil), do: {:ok, :halt, :done, nil}

--- a/lib/packmatic/encoder/encoding_state.ex
+++ b/lib/packmatic/encoder/encoding_state.ex
@@ -1,13 +1,16 @@
 defmodule Packmatic.Encoder.EncodingState do
   @moduledoc false
-  @type entry :: Packmatic.Manifest.Entry.t()
-  @type entry_source :: struct()
-  @type entry_info :: __MODULE__.EntryInfo.t()
+  alias Packmatic.Manifest.Entry
+  alias Packmatic.Source
+  alias __MODULE__.EntryInfo
+
+  @type entry_current :: {Entry.t(), Source.t(), EntryInfo.t()}
+  @type entry_encoded :: {Entry.t(), {:ok, EntryInfo.t()} | {:error, term()}}
 
   @type t :: %__MODULE__{
-          current: nil | {entry, entry_source, entry_info},
-          encoded: [{entry, {:ok, entry_info} | {:error, term()}}],
-          remaining: [entry],
+          current: nil | entry_current,
+          encoded: [entry_encoded],
+          remaining: [Entry.t()],
           zstream: nil | :zlib.zstream(),
           bytes_emitted: non_neg_integer(),
           on_error: :skip | :halt

--- a/lib/packmatic/encoder/journaling_state.ex
+++ b/lib/packmatic/encoder/journaling_state.ex
@@ -1,11 +1,10 @@
 defmodule Packmatic.Encoder.JournalingState do
   @moduledoc false
-  @type entry :: Packmatic.Manifest.Entry.t()
-  @type entry_info :: Packmatic.Encoder.EncodingState.EntryInfo.t()
+  alias Packmatic.Encoder.EncodingState
 
   @type t :: %__MODULE__{
           current: nil,
-          remaining: [{entry, {:ok, entry_info} | {:error, term()}}],
+          remaining: [EncodingState.entry_encoded()],
           offset: non_neg_integer(),
           entries_emitted: non_neg_integer(),
           bytes_emitted: non_neg_integer()

--- a/lib/packmatic/field.ex
+++ b/lib/packmatic/field.ex
@@ -1,5 +1,11 @@
 defprotocol Packmatic.Field do
-  @moduledoc false
+  @moduledoc """
+  Represents data fields used internally by `Packmatic.Encoder` to represent information which
+  make up the Zip format.
+  """
+
   @spec encode(t()) :: iodata() | no_return()
+
+  @doc "Encodes the given structure into an IO List, or crashes if the structure is invalid."
   def encode(field)
 end

--- a/lib/packmatic/field/central/file_header.ex
+++ b/lib/packmatic/field/central/file_header.ex
@@ -44,9 +44,9 @@ defmodule Packmatic.Field.Central.FileHeader do
   2.  The Compressed Size and Original Size fields are both set to `0xFF 0xFF 0xFF 0xFF`, in order
       to force the real sizes, set in the Zip64 Extended Information Extra Field (provided by
       `Packmatic.Field.Shared.ExtendedInformation`) to be used.
-  
+
   3.  The following Extra Fields are emitted:
-  
+
       - Extended Timestamp, see `Packmatic.Field.Shared.ExtendedTimestamp`
       - Zip64 Extended Information, see `Packmatic.Field.Shared.ExtendedInformation`
 

--- a/lib/packmatic/field/central/file_header.ex
+++ b/lib/packmatic/field/central/file_header.ex
@@ -1,7 +1,7 @@
 defmodule Packmatic.Field.Central.FileHeader do
   @moduledoc """
   Represents the Central Directory File Header, which is part of the Central Directory that is
-  emitted after all successfully encoded files have been incorporated into the ZIP stream.
+  emitted after all successfully encoded files have been incorporated into the Zip stream.
 
   ## Structure
 
@@ -10,7 +10,7 @@ defmodule Packmatic.Field.Central.FileHeader do
   Size     | Content
   -------- | -
   4 bytes  | Signature
-  1 byte   | Version made by - ZIP Specification Version
+  1 byte   | Version made by - Zip Specification Version
   1 byte   | Version made by - Environment
   2 bytes  | Version needed to extract
   2 bytes  | General Purpose Flag

--- a/lib/packmatic/field/local/data_descriptor.ex
+++ b/lib/packmatic/field/local/data_descriptor.ex
@@ -24,7 +24,7 @@ defmodule Packmatic.Field.Local.DataDescriptor do
   @type t :: %__MODULE__{
           checksum: non_neg_integer(),
           size_compressed: non_neg_integer(),
-          size: non_neg_integer(),
+          size: non_neg_integer()
         }
 
   @enforce_keys ~w(checksum size_compressed size)a

--- a/lib/packmatic/field/local/file_header.ex
+++ b/lib/packmatic/field/local/file_header.ex
@@ -40,7 +40,7 @@ defmodule Packmatic.Field.Local.FileHeader do
       contains relevant information.
 
   3.  The following Extra Field is emitted:
-  
+
       - Extended Timestamp, see `Packmatic.Field.Shared.ExtendedTimestamp`
   """
 

--- a/lib/packmatic/field/local/file_header.ex
+++ b/lib/packmatic/field/local/file_header.ex
@@ -1,7 +1,7 @@
 defmodule Packmatic.Field.Local.FileHeader do
   @moduledoc """
   Represents the Local File Header, which is emitted before the content of each file is
-  incorporated into the ZIP stream.
+  incorporated into the Zip stream.
 
   ## Structure
 

--- a/lib/packmatic/field/shared/extended_timestamp.ex
+++ b/lib/packmatic/field/shared/extended_timestamp.ex
@@ -16,7 +16,7 @@ defmodule Packmatic.Field.Shared.ExtendedTimestamp do
   4 bytes  | Modification Time (Seconds since UNIX Epoch)
 
   #### Notes
-  
+
   1.  The flag value is `1`, representing that Modification Time is set.
   """
 

--- a/lib/packmatic/field/shared/timestamp.ex
+++ b/lib/packmatic/field/shared/timestamp.ex
@@ -7,7 +7,7 @@ defmodule Packmatic.Field.Shared.Timestamp do
   first built separately
 
   ## Structure
-  
+
   Size     | Content
   -------- | -
   2 bytes  | Hour (5 bits), Minute (6 bits), Second / 2 (5 bits)

--- a/lib/packmatic/manifest.ex
+++ b/lib/packmatic/manifest.ex
@@ -55,21 +55,17 @@ defmodule Packmatic.Manifest do
 
   alias __MODULE__.Entry
 
+  entries = quote do: nonempty_list(Entry.t())
+  errors = quote do: nonempty_list(error)
+
   @typedoc "Represents the Manifest."
-  @type t :: %__MODULE__{entries: [entry], errors: [error], valid?: true | false}
+  @type t :: %__MODULE__{entries: [Entry.t()], errors: [error], valid?: true | false}
 
   @typedoc "Represents a valid Manifest, where there must be Entries and no errors."
-  @type valid :: %__MODULE__{entries: nonempty_list(entry), errors: [], valid?: true}
+  @type valid :: %__MODULE__{entries: unquote(entries), errors: [], valid?: true}
 
   @typedoc "Represents an invalid Manifest, where there must be errors and might be Entries."
-  @type invalid :: %__MODULE__{entries: list(entry), errors: nonempty_list(error), valid?: false}
-
-  @type entry :: Entry.t()
-  @type entry_keyword_source :: {:source, Entry.source()}
-  @type entry_keyword_path :: {:path, Entry.path()}
-  @type entry_keyword_timestamp :: {:timestamp, Entry.timestamp()}
-  @type entry_keyword_value :: entry_keyword_source | entry_keyword_path | entry_keyword_timestamp
-  @type entry_keyword :: nonempty_list(entry_keyword_value)
+  @type invalid :: %__MODULE__{entries: list(Entry.t()), errors: unquote(errors), valid?: false}
 
   @typedoc "Represents an Error which can be related to an Entry or the Manifest itself."
   @type error :: error_entry | error_manifest
@@ -88,8 +84,8 @@ defmodule Packmatic.Manifest do
 
   @spec create() :: invalid()
   @spec create([]) :: invalid()
-  @spec create(nonempty_list(entry | entry_keyword)) :: valid() | invalid()
-  @spec prepend(t(), entry | entry_keyword) :: valid() | invalid()
+  @spec create(nonempty_list(Entry.t() | Entry.proplist())) :: valid() | invalid()
+  @spec prepend(t(), Entry.t() | Entry.proplist()) :: valid() | invalid()
 
   @doc """
   Creates a Manifest based on Entries given. If there are no Entries, the Manifest will be

--- a/lib/packmatic/manifest.ex
+++ b/lib/packmatic/manifest.ex
@@ -1,29 +1,140 @@
 defmodule Packmatic.Manifest do
   @moduledoc """
-  Represents the customer’s request for a particular compressed file, which is composed of various
-  Source Entries.
+  Represents the customer’s request for a particular compressed file.
+
+  The Manifest is constructed with a list of `Packmatic.Manifest.Entry` structs, which each
+  represents one file to be placed into the Package. Entries are validated when they are added to
+  the Manifest.
+
+  ## Creating Manifests
+
+  Manifests can be created iteratively by calling `prepend/2` against an existing Manifest, or by
+  calling `create/1` with a list of Entries created elsewhere.
+
+  Calling `create/0` provides you with an empty Manifest which is not valid:
+
+      iex(1)> Packmatic.Manifest.create()
+      %Packmatic.Manifest{entries: [], errors: [manifest: :empty], valid?: false}
+
+  However, prepending valid Entries makes it valid:
+
+      iex(1)> manifest = Packmatic.Manifest.create()
+      iex(2)> manifest = Packmatic.Manifest.prepend(manifest, source: {:random, 1}, path: "foo")
+      iex(3)> manifest.valid?
+      true
+
+  Creating a Manifest from a list of Entries also results in a valid Manifest:
+
+      iex(1)> manifest = Packmatic.Manifest.create([[source: {:random, 1}, path: "foo"]])
+      iex(2)> manifest.valid?
+      true
+
+  ## Validity and Error Reporting
+
+  An empty Manifest is not valid because the result is not useful. It contains a Manifest-level
+  error `{:manifest, :empty}`.
+
+      iex(1)> manifest = Packmatic.Manifest.create()
+      iex(2)> manifest.errors
+      [manifest: :empty]
+
+  If an Entry is not valid when appended to a Manifest, it will make the Manifest invalid and a
+  corresponding error entry will also be added to the `:errors` key.
+
+  Since entries are prepended to the list, Entry-level errors are emitted with a negative index
+  (counted from the tail of the list). So the last item (first to be appended) has the index of
+  `-1`, the penultimate item has the index of `-2`, and so on.
+
+      iex(1)> manifest = Packmatic.Manifest.create()
+      iex(2)> manifest = Packmatic.Manifest.prepend(manifest, source: {:file, nil})
+      iex(3)> manifest.errors
+      [{{:entry, -1}, [source: :invalid, path: :missing]}]
+
+  Entry-level errors are emitted per key, and defined under `t:Packmatic.Manifest.Entry.error/0`.
   """
 
-  @type entry :: __MODULE__.Entry.t()
-  @type t :: %__MODULE__{entries: nonempty_list(entry)}
+  alias __MODULE__.Entry
+
+  @typedoc "Represents the Manifest."
+  @type t :: %__MODULE__{entries: [entry], errors: [error], valid?: true | false}
+
+  @typedoc "Represents a valid Manifest, where there must be Entries and no errors."
+  @type valid :: %__MODULE__{entries: nonempty_list(entry), errors: [], valid?: true}
+
+  @typedoc "Represents an invalid Manifest, where there must be errors and might be Entries."
+  @type invalid :: %__MODULE__{entries: list(entry), errors: nonempty_list(error), valid?: false}
+
+  @type entry :: Entry.t()
+  @type entry_keyword_source :: {:source, Entry.source()}
+  @type entry_keyword_path :: {:path, Entry.path()}
+  @type entry_keyword_timestamp :: {:timestamp, Entry.timestamp()}
+  @type entry_keyword_value :: entry_keyword_source | entry_keyword_path | entry_keyword_timestamp
+  @type entry_keyword :: nonempty_list(entry_keyword_value)
+
+  @typedoc "Represents an Error which can be related to an Entry or the Manifest itself."
+  @type error :: error_entry | error_manifest
+
+  @typedoc "Represents an Error regarding an Entry. Index is negative, counted from tail."
+  @type error_entry :: {{:entry, neg_integer()}, Entry.error()}
+
+  @typedoc "Represents an Error with the Manifest."
+  @type error_manifest :: {:manifest, error_manifest_reason}
+
+  @typedoc "Represents an error condition where the Manifest has no entries."
+  @type error_manifest_reason :: :empty
+
   @enforce_keys ~w(entries)a
-  defstruct entries: []
+  defstruct entries: [], errors: [], valid?: false
 
-  @spec create([entry]) :: t()
-  @spec prepend(t(), keyword()) :: t()
+  @spec create() :: invalid()
+  @spec create([]) :: invalid()
+  @spec create(nonempty_list(entry | entry_keyword)) :: valid() | invalid()
+  @spec prepend(t(), entry | entry_keyword) :: valid() | invalid()
 
-  def create(entries \\ []) do
-    %__MODULE__{entries: entries}
+  @doc """
+  Creates a Manifest based on Entries given. If there are no Entries, the Manifest will be
+  invalid by default. Otherwise, each Entry will be validated and the Manifest will remain valid
+  if all Entries provided were valid.
+  """
+  def create(entries \\ [])
+
+  def create([]) do
+    %__MODULE__{entries: [], errors: [{:manifest, :empty}], valid?: false}
   end
 
-  def prepend(model, keyword) do
-    entry = struct(__MODULE__.Entry, keyword)
+  def create(entries) when is_list(entries) do
+    for entry <- Enum.reverse(entries), reduce: %__MODULE__{entries: [], valid?: true} do
+      model -> prepend(model, entry)
+    end
+  end
+
+  @doc """
+  Prepends the given Entry to the Manifest. If the Entry is invalid, the Manifest will also
+  become invalid, and the error will be prepended to the list.
+  """
+  def prepend(model, target)
+
+  def prepend(%{entries: [], errors: [_ | _], valid?: false} = model, target) do
+    prepend(%{model | errors: [], valid?: true}, target)
+  end
+
+  def prepend(model, %Entry{} = entry) do
+    case Packmatic.Validator.validate(entry) do
+      :ok -> prepend_entry_valid(model, entry)
+      {:error, errors} -> prepend_entry_invalid(model, entry, errors)
+    end
+  end
+
+  def prepend(model, keyword) when is_list(keyword) do
+    prepend(model, struct(Entry, keyword))
+  end
+
+  defp prepend_entry_valid(model, entry) do
     %{model | entries: [entry | model.entries]}
   end
-end
 
-defimpl Packmatic.Validator.Target, for: Packmatic.Manifest do
-  def validate(%{entries: entries}, :entries) do
-    Packmatic.Validator.validate_each(entries)
+  defp prepend_entry_invalid(model, entry, errors) do
+    error = {{:entry, -1 * (1 + length(model.entries))}, errors}
+    %{model | entries: [entry | model.entries], errors: [error | model.errors], valid?: false}
   end
 end

--- a/lib/packmatic/manifest/entry.ex
+++ b/lib/packmatic/manifest/entry.ex
@@ -8,7 +8,15 @@ defmodule Packmatic.Manifest.Entry do
   """
 
   @type source :: Packmatic.Source.entry()
-  @type t :: %__MODULE__{source: source, path: Path.t(), timestamp: DateTime.t()}
+  @type path :: Path.t()
+  @type timestamp :: DateTime.t()
+  @type t :: %__MODULE__{source: source, path: path, timestamp: timestamp}
+
+  @type error_source :: {:source, :missing | :invalid}
+  @type error_path :: {:path, :missing}
+  @type error_timestamp :: {:timestamp, :missing | :invalid}
+  @type error :: error_source | error_path | error_timestamp
+
   @enforce_keys ~w(source path timestamp)a
   defstruct source: nil, path: nil, timestamp: DateTime.from_unix!(0)
 end

--- a/lib/packmatic/manifest/entry.ex
+++ b/lib/packmatic/manifest/entry.ex
@@ -3,14 +3,17 @@ defmodule Packmatic.Manifest.Entry do
   Represents a particular file that will go into package, which is sourced by reading from a file,
   downloading from an URI, etc.
 
-  The `source` in the Manifest Entry is actually just a Source Entry which will be dynamically
-  resolved at runtime when it is time for the Encoder to start reading from it.
+  The `source` in the Manifest Entry is a Source Entry (`t:Packmatic.Source.entry/0`), which will
+  be dynamically resolved at runtime using `Packmatic.Source.build/1` by the Encoder, when it is
+  time to start reading from it.
   """
+
+  @type t :: %__MODULE__{source: source, path: path, timestamp: timestamp}
+  @type proplist :: nonempty_list({:source, source} | {:path, path} | {:timestamp, timestamp})
 
   @type source :: Packmatic.Source.entry()
   @type path :: Path.t()
   @type timestamp :: DateTime.t()
-  @type t :: %__MODULE__{source: source, path: path, timestamp: timestamp}
 
   @type error_source :: {:source, :missing | :invalid}
   @type error_path :: {:path, :missing}

--- a/lib/packmatic/packmatic.ex
+++ b/lib/packmatic/packmatic.ex
@@ -1,6 +1,6 @@
 defmodule Packmatic do
   @moduledoc """
-  Top-level module holding the Packmatic library, which provides ZIP-oriented stream aggregation
+  Top-level module holding the Packmatic library, which provides Zip-oriented stream aggregation
   services from various sources.
   """
 
@@ -15,7 +15,7 @@ defmodule Packmatic do
   @spec build_stream(nonempty_list(unquote(manifest_entry)), unquote(options)) :: term()
 
   @doc """
-  Builds a Stream which can be consumed to construct a ZIP file from various sources, as specified
+  Builds a Stream which can be consumed to construct a Zip file from various sources, as specified
   in the Manifest. When building the Stream, options can be passed to configure how the Encoder
   should behave when Source acquisition fails.
 

--- a/lib/packmatic/packmatic.ex
+++ b/lib/packmatic/packmatic.ex
@@ -8,39 +8,39 @@ defmodule Packmatic do
   alias __MODULE__.Encoder
 
   @type manifest :: Manifest.t()
+  @type manifest_entry :: Manifest.entry() | Manifest.entry_keyword()
   @type options :: Encoder.options()
-  @type source_entry :: Packmatic.Source.entry()
-  @type source_path :: Path.t()
-  @type source_option :: {:timestamp, DateTime.t()}
-  @type stream_entry :: {source_entry, source_path}
-  @type stream_entry_extended :: {source_entry, source_path, nonempty_list(source_option)}
+
   @spec build_stream(manifest, options) :: term()
-  @spec build_stream(nonempty_list(stream_entry | stream_entry_extended), options) :: term()
+  @spec build_stream(nonempty_list(manifest_entry), options) :: term()
 
   @doc """
   Builds a Stream which can be consumed to construct a ZIP file from various sources, as specified
-  in the Manifest. When buinding the Stream, options can be passed to configure how the Encoder
+  in the Manifest. When building the Stream, options can be passed to configure how the Encoder
   should behave when Source acquisition fails.
 
   ## Examples
 
-      stream = Packmatic.build_stream([
-        {{:file, "/tmp/hello.pdf"}, "hello.pdf"},
-        {{:file, "/tmp/world.pdf"}, "world.pdf"}
-      ])
+  The Stream can be created by passing a `t:Packmatic.Manifest.t/0` struct, a list of Manifest
+  Entries (`t:Packmatic.Manifest.entry/0`), or a list of Keywords that are understood and can be
+  transformed to Manifest Entries (`t:Packmatic.Manifest.entry_keyword/0`).
 
-      stream = Packmatic.build_stream([
-        {{:file, "/tmp/htllo.pdf"}, "hello.pdf"},
-        {{:file, "/tmp/world.pdf"}, "world.pdf"}
-      ], on_error: :skip)
+      iex(1)> stream = Packmatic.build_stream(Packmatic.Manifest.create())
+      iex(2)> is_function(stream)
+      true
+
+      iex(1)> stream = Packmatic.build_stream([])
+      iex(2)> is_function(stream)
+      true
+
+      iex(1)> stream = Packmatic.build_stream([[source: {:file, "foo.bar"}]])
+      iex(2)> is_function(stream)
+      true
   """
-
   def build_stream(target, options \\ [])
 
   def build_stream(entries, options) when is_list(entries) do
-    entries
-    |> Enum.reduce(Manifest.create(), &build_stream_prepend/2)
-    |> build_stream(options)
+    entries |> Manifest.create() |> build_stream(options)
   end
 
   def build_stream(%Manifest{} = manifest, options) do
@@ -64,14 +64,5 @@ defmodule Packmatic do
     end
 
     Stream.resource(start_fun, next_fun, after_fun)
-  end
-
-  defp build_stream_prepend({source, path}, manifest) do
-    Manifest.prepend(manifest, source: source, path: path)
-  end
-
-  defp build_stream_prepend({source, path, options}, manifest) do
-    keyword = Keyword.merge(Keyword.take(options, ~w(timestamp)a), source: source, path: path)
-    Manifest.prepend(manifest, keyword)
   end
 end

--- a/lib/packmatic/packmatic.ex
+++ b/lib/packmatic/packmatic.ex
@@ -8,7 +8,7 @@ defmodule Packmatic do
   alias __MODULE__.Encoder
 
   @type manifest :: Manifest.t()
-  @type manifest_entry :: Manifest.entry() | Manifest.entry_keyword()
+  @type manifest_entry :: Manifest.Entry.t() | Manifest.Entry.proplist()
   @type options :: Encoder.options()
 
   @spec build_stream(manifest, options) :: term()
@@ -22,8 +22,8 @@ defmodule Packmatic do
   ## Examples
 
   The Stream can be created by passing a `t:Packmatic.Manifest.t/0` struct, a list of Manifest
-  Entries (`t:Packmatic.Manifest.entry/0`), or a list of Keywords that are understood and can be
-  transformed to Manifest Entries (`t:Packmatic.Manifest.entry_keyword/0`).
+  Entries (`t:Packmatic.Manifest.Entry.t/0`), or a list of Keyword Lists that are understood and
+  can be transformed to Manifest Entries (`t:Packmatic.Manifest.Entry.proplist/0`).
 
       iex(1)> stream = Packmatic.build_stream(Packmatic.Manifest.create())
       iex(2)> is_function(stream)

--- a/lib/packmatic/packmatic.ex
+++ b/lib/packmatic/packmatic.ex
@@ -7,12 +7,12 @@ defmodule Packmatic do
   alias __MODULE__.Manifest
   alias __MODULE__.Encoder
 
-  @type manifest :: Manifest.t()
-  @type manifest_entry :: Manifest.Entry.t() | Manifest.Entry.proplist()
-  @type options :: Encoder.options()
+  manifest = quote do: Manifest.t()
+  manifest_entry = quote do: Manifest.Entry.t() | Manifest.Entry.proplist()
+  options = quote do: [Encoder.option()]
 
-  @spec build_stream(manifest, options) :: term()
-  @spec build_stream(nonempty_list(manifest_entry), options) :: term()
+  @spec build_stream(unquote(manifest), unquote(options)) :: term()
+  @spec build_stream(nonempty_list(unquote(manifest_entry)), unquote(options)) :: term()
 
   @doc """
   Builds a Stream which can be consumed to construct a ZIP file from various sources, as specified

--- a/lib/packmatic/source.ex
+++ b/lib/packmatic/source.ex
@@ -53,6 +53,13 @@ defmodule Packmatic.Source do
   """
   @type entry :: unquote(Builder.build_quoted_entry_type(sources))
 
+  @typedoc """
+  Represents the internal (private) struct which holds runtime state for a resolved Source. In
+  case of a File source, this may hold the File Handle indirectly; in case of a URL source this
+  may indirectly refer to the underlying network socket.
+  """
+  @type t :: struct()
+
   for {name, module} <- sources do
     @spec build({unquote(name), unquote(module).init_arg()}) :: unquote(module).init_result()
   end

--- a/lib/packmatic/source.ex
+++ b/lib/packmatic/source.ex
@@ -2,18 +2,24 @@ defmodule Packmatic.Source do
   @moduledoc """
   Defines how data can be acquired in a piecemeal fashion, perhaps by reading only a few pages
   from the disk at a time or only a few MBs of data from an open socket.
+
+  The Source behaviour defines two functions, `init/1` and `read/1`, that must be implemented by
+  conforming modules. The first function initialises the Source and the second one iterates it,
+  reading more data until there is no more.
+
+  ## Representing Sources
+
+  Sources are represented in Manifest Entries as tuples such as `{:file, path}` or `{:url, url}`.
+  This form of representation is called a Source Entry; the first element in the tuple is the name
+  and the second element is called the Initialisation Argument (`init_arg`).
+
+  The Source Entry is a stable locator of the underlying data which has no runtime implications.
+  The Encoder hydrates the Source Entry into whatever the Source module implements internally,
+  when it is time to pull data from that source.
+
+  The Initialisation Argument is usually a basic Elixir type, but in the case of Dynamic Sources,
+  it is a function which resolves to a Source Entry understood by either the File or URL source.
   """
-
-  @type entry_file :: __MODULE__.File.entry()
-  @type entry_url :: __MODULE__.URL.entry()
-  @type entry_random :: __MODULE__.Random.entry()
-  @type entry_dynamic :: __MODULE__.Dynamic.entry()
-  @type entry :: entry_file | entry_url | entry_random | entry_dynamic
-
-  @spec build(entry_file) :: {:ok, __MODULE__.File.t()} | {:error, term()}
-  @spec build(entry_url) :: {:ok, __MODULE__.URL.t()} | {:error, term()}
-  @spec build(entry_random) :: {:ok, __MODULE__.Random.t()} | {:error, term()}
-  @spec build(entry_dynamic) :: {:ok, __MODULE__.Dynamic.t()} | {:error, term()}
 
   @doc "Converts the Entry to a Source, or return failure."
   @callback init(term()) :: {:ok, struct()} | {:error, term()}
@@ -21,11 +27,40 @@ defmodule Packmatic.Source do
   @doc "Iterates the Source and return data as an IO List, `:eof`, or failure."
   @callback read(struct()) :: iodata() | :eof | {:error, term()}
 
+  defmodule Builder do
+    @moduledoc false
+
+    def build_sources(source_names, module) do
+      for source_name <- source_names do
+        {:"#{String.downcase(source_name)}", Module.concat([module, source_name])}
+      end
+    end
+
+    def build_quoted_entry_type(sources) do
+      for {name, module} <- sources, reduce: [] do
+        acc -> [quote(do: {unquote(name), unquote(module).init_arg()}) | acc]
+      end
+    end
+  end
+
+  source_names = ~w(File URL Random Dynamic)
+  sources = Builder.build_sources(source_names, __MODULE__)
+
+  @typedoc """
+  Represents an internal tuple that can be used to initialise a Source with `build/1`. This allows
+  the Entries to be dynamically resolved. Dynamic sources use this to prepare their work lazily,
+  and other Sources may use this to open sockets or file handles.
+  """
+  @type entry :: unquote(Builder.build_quoted_entry_type(sources))
+
+  for {name, module} <- sources do
+    @spec build({unquote(name), unquote(module).init_arg()}) :: unquote(module).init_result()
+  end
+
   @doc "Transforms an Entry into a Source ready for acquisition. Called by `Packmatic.Encoder`."
-  def build({:file, path}), do: __MODULE__.File.init(path)
-  def build({:url, url}), do: __MODULE__.URL.init(url)
-  def build({:random, size}), do: __MODULE__.Random.init(size)
-  def build({:dynamic, resolve_fun}), do: __MODULE__.Dynamic.init(resolve_fun)
+  for {name, module} <- sources do
+    def build({unquote(name), init_arg}), do: unquote(module).init(init_arg)
+  end
 
   @doc "Consumes bytes off an initialised Source. Called by `Packmatic.Encoder`."
   def read(%{__struct__: module} = source), do: module.read(source)

--- a/lib/packmatic/source/dynamic.ex
+++ b/lib/packmatic/source/dynamic.ex
@@ -3,13 +3,52 @@ defmodule Packmatic.Source.Dynamic do
   Represents content which may be generated on-demand, for example by another subsystem or via
   downloading from a signed URL. The Dynamic source has no read function, and must initialise into
   a File or URL Source.
+
+  For example, a function which dynamically generates a URL (perhaps a signed S3 URL in your own
+  use case) would look like this:
+
+      iex(1)> url = "https://example.com"
+      iex(2)> {:ok, source} = Packmatic.Source.Dynamic.init(fn -> {:ok, {:url, url}} end)
+      iex(3)> source.__struct__
+      Packmatic.Source.URL
+
+  And when used within a Manifest, it would look like this:
+
+      iex(1)> url = "https://example.com"
+      iex(2)> init_arg = fn -> {:ok, {:url, url}} end
+      iex(3)> entry = [source: {:dynamic, init_arg}, path: "foo.pdf"]
+      iex(4)> manifest = Packmatic.Manifest.create([entry])
+      iex(5)> manifest.valid?
+      true
+
+  Even if the function (referenced by the Initialisation Argument) resolves cleanly, the result
+  may still be rejected by the underlying Source, for example if the file does not exist. This
+  kind of error “bubbles up” and is dealt with by the Encoder at runtime.
+
+      iex(1)> Packmatic.Source.Dynamic.init(fn -> {:ok, {:file, "example.pdf"}} end)
+      {:error, :enoent}
+
+  However, since resolution happens only when the built Stream starts to be consumed, such a
+  Source Entry would be valid when placed in a Manifest ahead of time:
+
+      iex(1)> path = "example.pdf"
+      iex(2)> init_arg = fn -> {:ok, {:file, path}} end
+      iex(3)> entry = [source: {:dynamic, init_arg}, path: "foo.pdf"]
+      iex(4)> manifest = Packmatic.Manifest.create([entry])
+      iex(5)> manifest.valid?
+      true
   """
 
   alias Packmatic.Source
-  @type resolve_fun :: (() -> {:ok, Source.File.entry() | Source.URL.entry()})
-  @type entry :: {:dynamic, resolve_fun}
-  @type t :: Source.File.t() | Source.URL.t()
-  @spec init(resolve_fun) :: t | {:error, atom()}
+
+  @type init_arg :: resolve_fun
+  @type init_result :: {:ok, Source.File.t() | Source.URL.t()} | {:error, term()}
+  @spec init(init_arg) :: init_result
+
+  @type resolve_fun :: (() -> resolve_result_file | resolve_result_url | resolve_result_error)
+  @type resolve_result_file :: {:ok, {:file, Source.File.init_arg()}}
+  @type resolve_result_url :: {:ok, {:url, Source.URL.init_arg()}}
+  @type resolve_result_error :: {:error, term()}
 
   def init(resolve_fun) do
     case resolve_fun.() do

--- a/lib/packmatic/source/file.ex
+++ b/lib/packmatic/source/file.ex
@@ -5,13 +5,15 @@ defmodule Packmatic.Source.File do
   """
 
   alias Packmatic.Source
-  @type entry :: {:file, String.t()}
-  @type t :: %__MODULE__{path: String.t(), device: File.io_device()}
+  @behaviour Source
 
+  @type init_arg :: String.t()
+  @type init_result :: {:ok, t}
+  @spec init(init_arg) :: init_result
+
+  @type t :: %__MODULE__{path: String.t(), device: File.io_device()}
   @enforce_keys ~w(path device)a
   defstruct path: nil, device: nil
-
-  @behaviour Source
 
   @impl Source
   def init(path) do

--- a/lib/packmatic/source/random.ex
+++ b/lib/packmatic/source/random.ex
@@ -5,13 +5,15 @@ defmodule Packmatic.Source.Random do
   """
 
   alias Packmatic.Source
-  @type entry :: {:random, non_neg_integer}
-  @type t :: %__MODULE__{agent_pid: pid()}
+  @behaviour Source
 
+  @type init_arg :: non_neg_integer
+  @type init_result :: {:ok, t}
+  @spec init(init_arg) :: init_result
+
+  @type t :: %__MODULE__{agent_pid: pid()}
   @enforce_keys ~w(agent_pid)a
   defstruct agent_pid: nil
-
-  @behaviour Source
 
   @impl Source
   def init(bytes_remaining) do

--- a/lib/packmatic/source/url.ex
+++ b/lib/packmatic/source/url.ex
@@ -62,7 +62,7 @@ defmodule Packmatic.Source.URL do
     Application.get_env(@otp_app, __MODULE__, [])
     |> Keyword.get(:whole_file_timeout, @default_whole_file_timeout)
   end
-  
+
   defp get_max_sessions do
     Application.get_env(@otp_app, __MODULE__, [])
     |> Keyword.get(:max_sessions, @default_max_sessions)

--- a/lib/packmatic/source/url.ex
+++ b/lib/packmatic/source/url.ex
@@ -5,13 +5,15 @@ defmodule Packmatic.Source.URL do
   """
 
   alias Packmatic.Source
-  @type entry :: {:uri, String.t()}
-  @type t :: %__MODULE__{url: String.t(), id: term()}
+  @behaviour Source
 
+  @type init_arg :: String.t()
+  @type init_result :: {:ok, t}
+  @spec init(init_arg) :: init_result
+
+  @type t :: %__MODULE__{url: String.t(), id: term()}
   @enforce_keys ~w(url id)a
   defstruct url: nil, id: nil
-
-  @behaviour Source
 
   @impl Source
   def init(url) do

--- a/lib/packmatic/validator.ex
+++ b/lib/packmatic/validator.ex
@@ -1,25 +1,10 @@
 defmodule Packmatic.Validator do
   @moduledoc false
   @spec validate(struct()) :: :ok | {:error, keyword()}
-  @spec validate_each([struct()]) :: :ok | {:error, [{struct(), keyword()}]}
   @spec errors(struct()) :: keyword()
 
   def validate(target) do
     case errors(target) do
-      [] -> :ok
-      list -> {:error, list}
-    end
-  end
-
-  def validate_each(targets) do
-    target_fun = fn target ->
-      case errors(target) do
-        [] -> []
-        list -> [{target, list}]
-      end
-    end
-
-    case Enum.flat_map(targets, target_fun) do
       [] -> :ok
       list -> {:error, list}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,16 @@ defmodule Packmatic.MixProject do
   defp docs do
     [
       main: "readme",
-      extras: ["README.md"]
+      extras: ["README.md"],
+      nest_modules_by_prefix: [
+        Packmatic.Manifest,
+        Packmatic.Source,
+        Packmatic.Field
+      ],
+      groups_for_modules: [
+        "Data Structs": [~r/\.Field/],
+        Helpers: [Packmatic.Conn]
+      ]
     ]
   end
 

--- a/test/packmatic/manifest_test.exs
+++ b/test/packmatic/manifest_test.exs
@@ -1,8 +1,7 @@
 defmodule Packmatic.ManifestTest do
   use ExUnit.Case, async: true
   alias Packmatic.Manifest
-
-  doctest Manifest
+  doctest Packmatic.Manifest
 
   describe "create/0" do
     test "returns invalid empty model" do

--- a/test/packmatic/manifest_test.exs
+++ b/test/packmatic/manifest_test.exs
@@ -1,0 +1,44 @@
+defmodule Packmatic.ManifestTest do
+  use ExUnit.Case, async: true
+  alias Packmatic.Manifest
+
+  doctest Manifest
+
+  describe "create/0" do
+    test "returns invalid empty model" do
+      assert %Manifest{valid?: false} = Manifest.create()
+    end
+  end
+
+  describe "create/1" do
+    test "returns invalid empty model if given empty list" do
+      assert %{valid?: false} = Manifest.create([])
+    end
+
+    test "returns valid model if given list with valid Entry model" do
+      source = {:file, "/tmp/example.com"}
+      path = "example.pdf"
+      timestamp = DateTime.utc_now()
+      entry = %Manifest.Entry{source: source, path: path, timestamp: timestamp}
+      assert %{valid?: true} = Manifest.create([entry])
+    end
+
+    test "returns valid model if given list with valid Entry keyword" do
+      entry = [source: {:file, "x"}, path: "example.pdf"]
+      assert %{valid?: true} = Manifest.create([entry])
+    end
+  end
+
+  describe "errors" do
+    test "preserve order of entries" do
+      entries = [
+        [path: "example.pdf"],
+        [source: {:file, "foo.pdf"}, timestamp: DateTime.utc_now()]
+      ]
+
+      assert %{valid?: false, errors: errors} = Manifest.create(entries)
+      assert {{:entry, -2}, [source: :missing]} = List.keyfind(errors, {:entry, -2}, 0)
+      assert {{:entry, -1}, [path: :missing]} = List.keyfind(errors, {:entry, -1}, 0)
+    end
+  end
+end

--- a/test/packmatic/packmatic_test.exs
+++ b/test/packmatic/packmatic_test.exs
@@ -1,5 +1,6 @@
 defmodule PackmaticTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
+
   doctest Packmatic
 
   setup do
@@ -19,11 +20,13 @@ defmodule PackmaticTest do
   end
 
   test "with no entries", context do
-    []
-    |> build_manifest()
-    |> Packmatic.build_stream()
-    |> Stream.into(File.stream!(context.file_path, [:write]))
-    |> Stream.run()
+    assert_raise Packmatic.StreamError, fn ->
+      []
+      |> build_manifest()
+      |> Packmatic.build_stream()
+      |> Stream.into(File.stream!(context.file_path, [:write]))
+      |> Stream.run()
+    end
   end
 
   test "with timestamp", context do

--- a/test/packmatic/packmatic_test.exs
+++ b/test/packmatic/packmatic_test.exs
@@ -1,6 +1,5 @@
 defmodule PackmaticTest do
   use ExUnit.Case, async: true
-
   doctest Packmatic
 
   setup do

--- a/test/packmatic/source/dynamic_test.exs
+++ b/test/packmatic/source/dynamic_test.exs
@@ -1,0 +1,4 @@
+defmodule Packmatic.Source.DynamicTest do
+  use ExUnit.Case, async: true
+  doctest Packmatic.Source.Dynamic
+end


### PR DESCRIPTION
**Revised Manifests handling**

- Revised Manifests so they are validated once, during creation.
  - Empty Manifests are invalid.
  - Manifests can be valid or invalid depending on their entries.
- Revised Encoder to not re-validate Manifests.
  - Encoder halts immediately if given an invalid Manifest.
- Removed `Packmatic.Validator.validate_each/1` as it is no longer useful.
- Revised tests.
  - Revised test on “no entries” case for invalid Manifest.
  - Added simple Manifest test with examples.
  - Made the top-level PackmaticTest asynchronous.

* * *

**Revised Sources handling**

- Eliminated duplicative types with code generation.
  - Known Sources are referred by name.
  - The Source Entry type is generated based on the names.
- Revised individual Source modules.
  - Standardised nomenclature (`init_arg`, `init_result`, etc) for type handling.
- Revised Manifest types.
  - Removed aliasing of `Manifest.Entry.t()`.
  - Renamed `Manifest.entry_keyword()` to `Manifest.Entry.proplist()`.
- Added further documentation on how Dynamic Sources work.
  - Added documentation within `Packmatic.Source.Dynamic`.
  - Added ExDoc test for inlined snippets.