### PR TITLE
Add Source.close/1 callback to prevent hitting file descriptor limits

### DIFF
--- a/lib/packmatic/encoder.ex
+++ b/lib/packmatic/encoder.ex
@@ -102,7 +102,9 @@ defmodule Packmatic.Encoder do
   defp stream_encode(%{current: {_, source, _}} = state) do
     case Source.read(source) do
       data when is_binary(data) -> stream_encode_data(data, state)
-      :eof -> stream_encode_eof(state)
+      :eof ->
+        Source.close(source)
+        stream_encode_eof(state)
       {:error, reason} -> stream_encode_error(reason, state)
     end
   end

--- a/lib/packmatic/source.ex
+++ b/lib/packmatic/source.ex
@@ -27,6 +27,9 @@ defmodule Packmatic.Source do
   @doc "Iterates the Source and return data as an IO List, `:eof`, or failure."
   @callback read(struct()) :: iodata() | :eof | {:error, term()}
 
+  @doc "Closes a Source (i.e. a file descriptor or http connection)"
+  @callback close(struct()) :: :ok | {:error, term()}
+
   defmodule Builder do
     @moduledoc false
 
@@ -71,4 +74,7 @@ defmodule Packmatic.Source do
 
   @doc "Consumes bytes off an initialised Source. Called by `Packmatic.Encoder`."
   def read(%{__struct__: module} = source), do: module.read(source)
+
+  @doc "Closes a Source after it has been fully processed. Called by `Packmatic.Encoder`."
+  def close(%{__struct__: module} = source), do: module.close(source)
 end

--- a/lib/packmatic/source/file.ex
+++ b/lib/packmatic/source/file.ex
@@ -27,6 +27,11 @@ defmodule Packmatic.Source.File do
     IO.binread(source.device, get_chunk_size())
   end
 
+  @impl Source
+  def close(source) do
+    File.close(source.device)
+  end
+
   @otp_app Mix.Project.config()[:app]
   @default_chunk_size 4096
 

--- a/lib/packmatic/source/random.ex
+++ b/lib/packmatic/source/random.ex
@@ -37,10 +37,14 @@ defmodule Packmatic.Source.Random do
     end
 
     with <<>> <- Agent.get_and_update(source.agent_pid, get_and_update_fun) do
-      :ok = Agent.stop(source.agent_pid)
       :eof
     else
       result -> result
     end
+  end
+
+  @impl Source
+  def close(%__MODULE__{} = source) do
+    Agent.stop(source.agent_pid)
   end
 end

--- a/lib/packmatic/source/url.ex
+++ b/lib/packmatic/source/url.ex
@@ -42,6 +42,11 @@ defmodule Packmatic.Source.URL do
     end
   end
 
+  @impl Source
+  def close(%__MODULE__{id: id}) do
+    :ibrowse.stream_close(id)
+  end
+
   @otp_app Mix.Project.config()[:app]
   @default_whole_file_timeout 1000 * 60 * 30
   @default_max_sessions 100


### PR DESCRIPTION
Hey evadne,

thank you very much for this great package, it works fantastically and is a pleasure to work with.

I found one issue where generating large archives from local files (1000+) would crash with `reason: :emfile` (i.e. too many open files). 
File sources were simply never closed in the Encoder loop.

My fix is to add a new `Source.close/1` callback, which is called after `:eof` is received from the source.
This also seemed to apply to the URL and Random source, so I implemented matching behaviours there, too.

The tests were a little hard to follow for me, so this is still a work in progress and any advice would be appreciated.
I verified that the problem is fixed regarding file sources, but did not test (other than running `mix test` - which is green) anything regarding URL or Random.

Let me know what you think!

Cheers,
Christoph