### PR TITLE
Prevent warning when using with elixir 1.16

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Packmatic.MixProject do
     [
       app: :packmatic,
       version: "1.2.0",
-      elixir: "~> 1.15.7",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       package: package(),


### PR DESCRIPTION
Don't pin to Elixir minor version `1.15`:

```sh
$ mix compile
...
warning: the dependency :packmatic requires Elixir "~> 1.15.7" but you are running on v1.16.1
```