### PR TITLE
Replace `~>` with `>=` for Elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Packmatic.MixProject do
     [
       app: :packmatic,
       version: "1.2.0",
-      elixir: "~> 1.15.7",
+      elixir: ">= 1.15.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       package: package(),


### PR DESCRIPTION
Similar to https://github.com/evadne/packmatic/pull/18

That one will warn if/when Elixir goes to 2.0, this one wouldn't. Dealer's choice.