### PR TITLE
Allow configuration of compression level

### DIFF
--- a/lib/packmatic/encoder.ex
+++ b/lib/packmatic/encoder.ex
@@ -45,7 +45,7 @@ defmodule Packmatic.Encoder do
   - `on_event` can be set to a function which will be called when events are raised by the Encoder
     during its lifecycle. See `Packmatic.Event` for further information.
   """
-  @type option :: {:on_error, :skip | :halt} | {:on_event, Event.handler_fun()}
+  @type option :: {:on_error, :skip | :halt} | {:on_event, Event.handler_fun()} | {:compression_level, :zlib.zlevel()}
 
   @typedoc """
   Represents an unique identifier of the Stream in operation. This allows you to distinguish

--- a/lib/packmatic/encoder/encoding.ex
+++ b/lib/packmatic/encoder/encoding.ex
@@ -27,10 +27,10 @@ defmodule Packmatic.Encoder.Encoding do
   def encoding_start(%Manifest{valid?: true} = manifest, options) do
     id = make_ref()
     entries = manifest.entries
-    on_error = Keyword.get(options, :on_error, :halt)
-    on_event = Keyword.get(options, :on_event)
+    {on_error, options} = Keyword.pop(options, :on_error, :halt)
+    {on_event, options} = Keyword.pop(options, :on_event)
 
-    %EncodingState{stream_id: id, remaining: entries, on_error: on_error, on_event: on_event}
+    %EncodingState{stream_id: id, remaining: entries, on_error: on_error, on_event: on_event, options: options}
     |> Event.emit_stream_started()
     |> cont()
   end
@@ -149,9 +149,10 @@ defmodule Packmatic.Encoder.Encoding do
     # > undocumented feature.
     #
     # With the default WindowBits value of 15, deflate fails on macOS.
+    compression_level = state.options[:compression_level] || :default
 
     zstream = :zlib.open()
-    :ok = :zlib.deflateInit(zstream, :default, :deflated, -15, 8, :default)
+    :ok = :zlib.deflateInit(zstream, compression_level, :deflated, -15, 8, :default)
     %{state | zstream: zstream}
   end
 

--- a/lib/packmatic/encoder/encoding_state.ex
+++ b/lib/packmatic/encoder/encoding_state.ex
@@ -13,6 +13,7 @@ defmodule Packmatic.Encoder.EncodingState do
           remaining: [Entry.t()],
           zstream: nil | :zlib.zstream(),
           bytes_emitted: non_neg_integer(),
+          options: Keyword.t(),
           on_error: :skip | :halt,
           on_event: nil | Event.handler_fun()
         }
@@ -25,6 +26,7 @@ defmodule Packmatic.Encoder.EncodingState do
             remaining: [],
             zstream: nil,
             bytes_emitted: 0,
+            options: [],
             on_error: :skip,
             on_event: nil
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Packmatic.MixProject do
     [
       app: :packmatic,
       version: "1.2.0",
-      elixir: "~> 1.15.7",
+      elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       package: package(),

--- a/test/packmatic/packmatic_test.exs
+++ b/test/packmatic/packmatic_test.exs
@@ -170,6 +170,32 @@ defmodule PackmaticTest do
     assert {_, 0} = System.cmd("zipinfo", [context.file_path])
   end
 
+  test "with compression_level" do
+    {:ok, file_larger} = Briefly.create()
+    {:ok, file_smaller} = Briefly.create()
+
+    [
+      {{:stream, Stream.repeatedly(fn -> "a" end) |> Stream.take(8 * 1_024)}, "compressable.bin"}
+    ]
+    |> build_manifest()
+    |> Packmatic.build_stream(compression_level: :none)
+    |> Stream.into(File.stream!(file_larger, [:write]))
+    |> Stream.run()
+
+    [
+      {{:stream, Stream.repeatedly(fn -> "a" end) |> Stream.take(8 * 1_024)}, "compressable.bin"}
+    ]
+    |> build_manifest()
+    |> Packmatic.build_stream(compression_level: 9)
+    |> Stream.into(File.stream!(file_smaller, [:write]))
+    |> Stream.run()
+
+    assert {_, 0} = System.cmd("zipinfo", [file_larger])
+    assert {_, 0} = System.cmd("zipinfo", [file_smaller])
+
+    assert File.stat!(file_larger).size > File.stat!(file_smaller).size
+  end
+
   defp get_sorted_zip_files(target) do
     get_zip_files(target) |> Enum.sort()
   end


### PR DESCRIPTION
Resolves #21 

Adds `compression_level` as an option to pass through `Packmatic.build_stream` that will be given to `:zlib.deflateInit` as the compression level. The default is still `:default` when not supplied (which I think zlib defaults to 6).

Also provides an alternative to #22 for relaxing Elixir version so we can run on later Elixir versions without warnings. Includes changes from #18